### PR TITLE
Containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,11 @@ WORKDIR /src
 RUN touch README.rst CHANGES.rst
 COPY Makefile ./
 
-# This part is rebuilt if dependencies change
-COPY Pipfile Pipfile.lock setup.py ./
+COPY Pipfile Pipfile.lock setup.py setup.cfg ./
 RUN make init
 
-# This part is rebuilt if assets change
-COPY assets/ ./assets/
+COPY . .
 RUN make assets
 
-COPY . .
 ENTRYPOINT ["pipenv", "run"]
 CMD ["fbctl", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.6-stretch
+RUN pip install pipenv==11.1.3
+
+RUN apt-get update -yq \
+ && apt-get install curl gnupg -yq \
+ && curl -sL https://deb.nodesource.com/setup_8.x | bash \
+ && apt-get install nodejs -yq \
+ && apt-get autoremove -y
+RUN npm install -g yarn
+
+WORKDIR /src
+RUN touch README.rst CHANGES.rst
+COPY Makefile ./
+
+# This part is rebuilt if dependencies change
+COPY Pipfile Pipfile.lock setup.py ./
+RUN make init
+
+# This part is rebuilt if assets change
+COPY assets/ ./assets/
+RUN make assets
+
+COPY . .
+ENTRYPOINT ["pipenv", "run"]
+CMD ["fbctl", "serve"]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -136,7 +136,7 @@
         },
         "hiredis": {
             "hashes": [
-                "sha256:ca958e13128e49674aa4a96f02746f5de5973f39b57297b84d59fd44d314d5b5"
+                "sha256:3f8b334c59c474e2b92580d7f4fb6503a08c013ae8a877ffc5c252f899d90ac6"
             ],
             "version": "==0.2.0"
         },
@@ -467,7 +467,8 @@
                 "sha256:a1daf9c5120f3cc6f2b5fef8e1d2a3fb7bbbb20ed4bfdc25bc8364bc62dcf54b",
                 "sha256:e6b77ae84f2b8502d99a7855fa33334a1eb6159de45626905cb3e454c023f339",
                 "sha256:e881ef610ff48aece2f4ee2af03d2db1a146dc7c705561bd6089b2356f61641f",
-                "sha256:f41037260deaacb875db250021fe883bf536bf6414a4fd25b25059b02e31b120"
+                "sha256:f41037260deaacb875db250021fe883bf536bf6414a4fd25b25059b02e31b120",
+                "sha256:727aa737a48dd33d6859296f15edb54e85ccdfa5667513f7a50daf362b3df75b"
             ],
             "version": "==4.5.0"
         },

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ Fanboi2 requires the following packages to be installed.
 - `Python 3.6 <https://www.python.org/downloads/>`_ with `Pipenv <https://pipenv.readthedocs.io>`_
 - `PostgreSQL 10 <http://www.postgresql.org/>`_
 - `Redis <http://redis.io/>`_
+- `Memcached <https://memcached.org/>`_
 - `Node 8 <http://nodejs.org/>`_ with `Yarn <https://yarnpkg.com/>`_ (Node 10 will NOT work)
 
 After all packages are installed and started, you may now clone the application::
@@ -62,7 +63,10 @@ Key                       Description
 Contributing
 ------------
 
-Fanboi2 is open to any contributors, whether you are learning Python or an expert. To contribute to Fanboi2, it is highly recommended to use `Vagrant`_ as it is currently replicating the production environment of `Fanboi Channel`_ and perform all the necessary setup steps for you. You can follow these steps to get the app running:
+Fanboi2 is open to any contributors, whether you are learning Python or an expert. To contribute to Fanboi2, it is highly recommended to use `Vagrant`_ as it is currently replicating the production environment of `Fanboi Channel`_ and perform all the necessary setup steps for you. Alternatively, if containers are your thing, you can find experimental, unsupported Docker Compose scripts in ``contrib/``.
+
+Vagrant
+^^^^^^^
 
 1. Install `Vagrant`_ of your preferred platform.
 2. Install `VirtualBox`_ or other providers supported by Vagrant.
@@ -78,6 +82,22 @@ You can then configure the application (see configuration section) and run the s
 
   $ make migrate
   $ pipenv run honcho start -f Procfile.dev
+
+Docker
+^^^^^^
+
+1. Install ``Docker`` and ``Docker Compose``
+2. Copy Compose configuration files to the application's parent directory (``cp contrib/docker-compose.* ../``)
+3. Modify the content of ``docker-compose.yml``
+   1. Generate both ``AUTH_SECRET`` and ``SESSION_SECRET`` tokens with ``openssl rand -hex 32``
+   2. Set a sensible Postgres password
+   3. This config assumes fanboi2 was cloned to ``fanboi2``; update the build and mount paths if untrue
+4. Start the contraption with ``docker-compose up`` from the same directory as the config files.
+
+By default, Fanboi2 will start in development mode which aids debugging. To disable development server capabilities, remove or rename the file ``docker-compose.override.yml`.
+
+Submitting Pull Requests
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once you've made your changes, simply open a `pull request <https://github.com/forloopend/fanboi2/pulls>`_ against the **master** branch. Our reviewer will review and merge the pull request as soon as possible. It would be much appreciated if you could follow the following guidelines:
 

--- a/README.rst
+++ b/README.rst
@@ -89,12 +89,14 @@ Docker
 1. Install ``Docker`` and ``Docker Compose``
 2. Copy Compose configuration files to the application's parent directory (``cp contrib/docker-compose.* ../``)
 3. Modify the content of ``docker-compose.yml``
+
    1. Generate both ``AUTH_SECRET`` and ``SESSION_SECRET`` tokens with ``openssl rand -hex 32``
    2. Set a sensible Postgres password
    3. This config assumes fanboi2 was cloned to ``fanboi2``; update the build and mount paths if untrue
+
 4. Start the contraption with ``docker-compose up`` from the same directory as the config files.
 
-By default, Fanboi2 will start in development mode which aids debugging. To disable development server capabilities, remove or rename the file ``docker-compose.override.yml`.
+By default, Fanboi2 will start in development mode which aids debugging. To disable development server capabilities, remove or rename the file ``docker-compose.override.yml``.
 
 Submitting Pull Requests
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/contrib/docker-compose.override.yml
+++ b/contrib/docker-compose.override.yml
@@ -1,0 +1,7 @@
+version: '2.2'
+services:
+
+  web:
+    environment:
+      SERVER_DEV: "true"
+    command: fbctl serve --reload

--- a/contrib/docker-compose.yml
+++ b/contrib/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '2.2'
+
+x-app:
+  &app-defaults
+  build: ./fanboi2
+  volumes:
+    - ./fanboi2:/src
+  links:
+    - postgres
+    - redis
+    - memcached
+  environment:
+    AUTH_SECRET: <REPLACE WITH SECRET>
+    SESSION_SECRET: <REPLACE WITH SECRET>
+    DATABASE_URL: postgres://postgres:<REPLACE WITH PASSWORD>@postgres/fanboi2
+    MEMCACHED_URL: memcached:11211
+    REDIS_URL: redis://redis/0
+    CELERY_BROKER_URL: redis://redis/1
+
+services:
+  web:
+    <<: *app-defaults
+    ports:
+      - '6543:6543'
+
+  worker:
+    <<: *app-defaults
+    command: fbcelery worker
+
+  assets:
+    <<: *app-defaults
+    working_dir: /src/assets
+    command: yarn run gulp watch
+
+  migrations:
+    <<: *app-defaults
+    command: make migrate
+
+  postgres:
+    image: postgres:10.5-alpine
+    environment:
+      POSTGRES_PASSWORD: <REPLACE WITH PASSWORD>
+      POSTGRES_DB: fanboi2
+
+  redis:
+    image: redis:5.0-alpine
+
+  memcached:
+    image: memcached:1.5-alpine


### PR DESCRIPTION
`hiredis` and `zope.interface` have been rereleased and the older `Pipfile.lock` no longer runs on a fresh installation.