### PR TITLE
Update Docker-Compose config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,9 @@ COPY Makefile gulpfile.js package.json tsconfig.json yarn.lock ./
 COPY assets ./assets
 
 RUN set -xe \
- && apk add --update --no-cache --virtual .assets-build \
+ && apk add --update --no-cache --virtual .run-deps \
         make \
- && make assets \
- && apk del .assets-build
+ && make assets
 
 FROM python:3.6-alpine
 

--- a/vendor/docker/README.rst
+++ b/vendor/docker/README.rst
@@ -1,0 +1,25 @@
+============================
+Docker Compose Configuration
+============================
+
+These configuration are intended to help you launch Fanboi2 and all its dependencies on one machine, mainly for development/staging. For a real production deployment, you will want to use container orchestration tools such as Docker Swarm or Kubernetes, which are beyond the scope of this document.
+
+Setting Up
+----------
+
+These configuration files assume the following directory structure::
+
+  project_root/
+  ├── docker-compose.yml
+  ├── docker-compose.override.yml
+  └── fanboi2/
+      └── <REPOSITORY CONTENT>
+
+1. Create the above directory structure by copying both `yml` files to the same level as the repository directory
+2. Edit the content of `docker-compose.yml` and initialize the variables with freshly generated secret tokens
+3. Run `docker-compose build && docker-compose up -d` from the context of `project_root` (*not* the repository root)
+
+Disabling Code Reload
+---------------------
+
+Removing or renaming `docker-compose.override.yml` to something else will prevent automatic reloading and rebuilding of code, similar to when in production. Don't forget to re-run `docker-compose up -d` when you make any changes.

--- a/vendor/docker/docker-compose.override.yml
+++ b/vendor/docker/docker-compose.override.yml
@@ -1,7 +1,15 @@
-version: '2.2'
+version: '2.3'
 services:
 
   web:
     environment:
       SERVER_DEV: "true"
-    command: fbctl serve --reload
+    command: devserve
+
+  assets:
+    build:
+      context: ./fanboi2
+      target: assets
+    volumes:
+      - ./fanboi2:/src
+    command: make devassets

--- a/vendor/docker/docker-compose.yml
+++ b/vendor/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.2'
+version: '2.3'
 
 x-app:
   &app-defaults
@@ -24,12 +24,6 @@ services:
   worker:
     <<: *app-defaults
     command: worker
-
-  assets:
-    <<: *app-defaults
-    target: assets
-    working_dir: /src
-    command: yarn run gulp watch
 
   migrations:
     <<: *app-defaults


### PR DESCRIPTION
Following changes in #51, this PR updates docker-compose configuration to use the new make targets, as well as take advantage of the multi-stage container build process.

Compose file version has been bumped to 2.3 which is the minimum required to support build targets.